### PR TITLE
Fix cache for htmltest

### DIFF
--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -23,9 +23,30 @@ jobs:
         with:
           fetch-depth: 0 # Necessary for git diff in vale step
 
+      # Cache for Antora UI and Htmltest.
+      # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
+      # Htmltest accepts 2 weeks old cache for the status code of checked external URLs
+      # See: https://github.com/wjdp/htmltest
+      # Refresh the cache every week to avoid a stale cache for htmltest
+      # See: https://github.com/actions/cache
+      # See: http://man7.org/linux/man-pages/man1/date.1.html
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=yearweek::$(/bin/date -u "+%Y%U")"
+        shell: bash
+      - name: Restore cache
+        uses: actions/cache@v2
+        env:
+          cache-name: cache
+        with:
+          path: .cache
+          key: ${{ steps.get-date.outputs.yearweek }}
+
       - name: Build using antora # and fail on warning
         id: antora-build
         run: CI=true antora generate antora-playbook-for-development.yml --stacktrace 2>&1 | (tee | grep  WARNING && exit 42 || exit 0)
+
       - name: Upload artifact doc-content
         uses: actions/upload-artifact@v2
         with:
@@ -45,13 +66,7 @@ jobs:
         with:
           name: pull-request-sha
           path: PR_SHA
-      - name: Cache htmltest status code of checked external URLs # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-htmltest
-        with:
-          key: refcache.json
-          path: .cache/htmltest
+
       - name: Validate links using htmltest
         id: validate-links
         run: htmltest


### PR DESCRIPTION
Cache for Antora UI and Htmltest.
See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
Htmltest accepts 2 weeks old cache for the status code of checked external URLs
See: https://github.com/wjdp/htmltest
Refresh the cache every week to avoid a stale cache for htmltest
See: https://github.com/actions/cache
See: http://man7.org/linux/man-pages/man1/date.1.html