### PR TITLE
Set the alert level of the Spelling rule to warning rather than error

### DIFF
--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -1,6 +1,7 @@
 extends: spelling
 message: "Did you really mean '%s'?"
-level: error
+# Set to warning rather than error, to ease onboarding of new projects.
+level: warning
 link: https://vale-at-red-hat.github.io/vale-at-red-hat/docs/contributor-guide/extending-the-spelling-rule/
 # A "filter" is a case-sensitive regular expression specifying words
 # to ignore during spell checking.


### PR DESCRIPTION
To ease onboarding of new projects, set the alert level of the Spelling rule to warning rather than error. On new project it is expected that you need to adapt the Spelling rule to add new words in the dictionary (mostly products).