### PR TITLE
fix: don't raise an error for 'shell'

### DIFF
--- a/.vale/styles/RedHat/shell-prompt.yml
+++ b/.vale/styles/RedHat/shell-prompt.yml
@@ -7,4 +7,4 @@ action:
   name: replace
 source: Red Hat
 swap:
-  command prompt|terminal|shell: shell prompt
+  command prompt|terminal: shell prompt


### PR DESCRIPTION
A "shell" is a software application (for example, /bin/bash or /bin/sh) that provides an interface to a computer. Do not use this term to describe the prompt where you type commands.