### PR TITLE
feat: add [dD]ev[wW]orkspace and Traefik to the Spelling rule

### DIFF
--- a/.vale/styles/RedHat/Spelling.yml
+++ b/.vale/styles/RedHat/Spelling.yml
@@ -22,6 +22,7 @@ filters:
   - "[cC]onfig" # to enable "config map"
   - "[dD]evfile"
   - "[dD]evfiles"
+  - "[dD]ev[wW]orkspace"
   - "[dD]ownstream"
   - "[dD]ownstreaming"
   - "[eE]xposal"
@@ -226,6 +227,7 @@ filters:
   - Tensorflow
   - Texinfo
   - Toolset
+  - Traefik
   - Uber
   - URI
   - URIs


### PR DESCRIPTION
Add [dD]ev[wW]orkspace and Traefik to the Spelling rule.

Required for: https://github.com/eclipse/che-docs/pull/2125