### PR TITLE
fix: remove warning on "additional"

### DIFF
--- a/.vale/styles/RedHat/ComplexWords.yml
+++ b/.vale/styles/RedHat/ComplexWords.yml
@@ -18,7 +18,6 @@ swap:
   accurate: "'right' or 'exact'"
   acquiesce: "'agree'"
   acquire: "'get' or 'buy'"
-  additional: "'more' or 'extra'"
   address: "'discuss'"
   addressees: "'you'"
   adjacent to: "'next to'"


### PR DESCRIPTION
Don't raise a warning for "Additional resources"