### PR TITLE
fix: #139 Duplicate rule: 'refer to'

### DIFF
--- a/.vale/styles/RedHat/Wordiness.yml
+++ b/.vale/styles/RedHat/Wordiness.yml
@@ -87,7 +87,7 @@ swap:
   it would appear that: apparently
   lift up: lift
   made reference to: referred to
-  make reference to: refer to
+  make reference to: see
   mix together: mix
   none at all: none
   not in a position to: unable


### PR DESCRIPTION
fixes #139 

Keep reference to 'refer to' only in the see.yml rule.
Remove it from Wordiness.yml.
It is already absent from Usage.yml, the issue is referring to an older version of the rule.